### PR TITLE
feat: Add slide transition animation for Results screen

### DIFF
--- a/navigation/src/main/java/pl/flashrow/navigation/DestinationsRoot.kt
+++ b/navigation/src/main/java/pl/flashrow/navigation/DestinationsRoot.kt
@@ -2,9 +2,14 @@ package pl.flashrow.navigation
 
 import androidx.compose.runtime.Composable
 import com.ramcosta.composedestinations.DestinationsNavHost
+import com.ramcosta.composedestinations.animations.rememberNavHostEngine
 import com.ramcosta.composedestinations.generated.NavGraphs
 
 @Composable
 fun DestinationsRoot() {
-    DestinationsNavHost(navGraph = NavGraphs.root)
+    val engine = rememberNavHostEngine()
+    DestinationsNavHost(
+        navGraph = NavGraphs.root,
+        engine = engine
+    )
 }

--- a/navigation/src/main/java/pl/flashrow/navigation/destinations/ResultsDestination.kt
+++ b/navigation/src/main/java/pl/flashrow/navigation/destinations/ResultsDestination.kt
@@ -6,8 +6,9 @@ import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import pl.flashrow.calculator.presentation.results.ResultsScreen
 import pl.flashrow.navigation.provided.ProvidedResultNavigation
+import pl.flashrow.navigation.transitions.ResultsScreenTransition
 
-@Destination<RootGraph>()
+@Destination<RootGraph>(style = ResultsScreenTransition::class)
 @Composable
 fun Results(navigator: DestinationsNavigator, result: ResultsNavArgs) {
     ResultsScreen(

--- a/navigation/src/main/java/pl/flashrow/navigation/transitions/NavigationTransitions.kt
+++ b/navigation/src/main/java/pl/flashrow/navigation/transitions/NavigationTransitions.kt
@@ -1,0 +1,43 @@
+package pl.flashrow.navigation.transitions
+
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.navigation.NavBackStackEntry
+import com.ramcosta.composedestinations.spec.DestinationStyle
+
+@OptIn(ExperimentalAnimationApi::class)
+object ResultsScreenTransition : DestinationStyle.Animated {
+
+    override fun AnimatedContentScope<NavBackStackEntry>.enterTransition(): EnterTransition? {
+        return slideInHorizontally(
+            initialOffsetX = { it }, // Slide in from right
+            animationSpec = tween(durationMillis = 300)
+        )
+    }
+
+    override fun AnimatedContentScope<NavBackStackEntry>.exitTransition(): ExitTransition? {
+        return slideOutHorizontally(
+            targetOffsetX = { -it }, // Slide out to left
+            animationSpec = tween(durationMillis = 300)
+        )
+    }
+
+    override fun AnimatedContentScope<NavBackStackEntry>.popEnterTransition(): EnterTransition? {
+        return slideInHorizontally(
+            initialOffsetX = { -it }, // Slide in from left (when popping)
+            animationSpec = tween(durationMillis = 300)
+        )
+    }
+
+    override fun AnimatedContentScope<NavBackStackEntry>.popExitTransition(): ExitTransition? {
+        return slideOutHorizontally(
+            targetOffsetX = { it }, // Slide out to right (when popping)
+            animationSpec = tween(durationMillis = 300)
+        )
+    }
+}


### PR DESCRIPTION
Implemented a slide-in/slide-out animation when navigating between the Calculator screen and the Results screen.

Changes include:
- Created `NavigationTransitions.kt` to define `ResultsScreenTransition` using `DestinationStyle.Animated`.
- Updated `DestinationsRoot.kt` to use `rememberNavHostEngine` to enable animations.
- Applied `ResultsScreenTransition` to the `@Destination` annotation in `ResultsDestination.kt`.